### PR TITLE
Update login-announcements

### DIFF
--- a/login-announcements
+++ b/login-announcements
@@ -1,7 +1,7 @@
 [   
    {
       "type":"Critical",
-      "title": "BitCraft Demo - Demo Closes Today at 6PM EST time!",
-      "description": "Thank you to everyone who participated in the demo! We received a ton of useful feedback and encouragement. If you enjoyed the demo, please consider wishlisting the game on Steam. BitCraft is entering Early Access on June 20th. We hope to see you back in just a few days!"
+      "title": "BitCraft Demo - Server Closes on June 17th at 6PM EST time!",
+      "description": "BitCraft Online was one of the most played demos of Steam Next Fest, so we have decided to extend the demo by 24 hours! Thank you to everyone who participated in the demo! We received a ton of useful feedback and encouragement. If you enjoyed the demo, please consider wishlisting the game on Steam. BitCraft is entering Early Access on June 20th. We hope to see you back in just a few days!"
    }
 ]


### PR DESCRIPTION
New text:

"title": "BitCraft Demo - Server Closes on June 17th at 6PM EST time!",
"description": "BitCraft Online was one of the most played demos of Steam Next Fest, so we have decided to extend the demo by 24 hours! Thank you to everyone who participated in the demo! We received a ton of useful feedback and encouragement. If you enjoyed the demo, please consider wishlisting the game on Steam. BitCraft is entering Early Access on June 20th. We hope to see you back in just a few days!"